### PR TITLE
Fix: Make theme preference persistent

### DIFF
--- a/Components/Pages/Settings.razor
+++ b/Components/Pages/Settings.razor
@@ -10,7 +10,8 @@
     <MudTabPanel Text="Perfil" Icon="@Icons.Material.Filled.Person"/>
     <MudTabPanel Text="Visual" Icon="@Icons.Material.Filled.Brightness6">
         <MudSwitch T="bool"
-                   @bind-Value="@ThemeService.IsDarkMode"
+                   Value="@ThemeService.IsDarkMode"
+                   ValueChanged="@OnThemeSwitchChanged"
                    ThumbIcon="@ThemeIcon"
                    Color="Color.Primary"
                    Label="@ThemeLabel"
@@ -29,4 +30,8 @@
     private string ThemeLabel => ThemeService.IsDarkMode ? "Modo escuro" : "Modo claro";
     private string ThemeIcon => ThemeService.IsDarkMode ? Icons.Material.Filled.DarkMode : Icons.Material.Filled.LightMode;
 
+    private async Task OnThemeSwitchChanged(bool newValue)
+    {
+        await ThemeService.SetDarkModeAsync(newValue);
+    }
 }


### PR DESCRIPTION
I modified Settings.razor to correctly call ThemeService.SetDarkModeAsync when the theme switch is toggled.

This ensures that your selected theme (dark or light) is saved to local storage and reloaded when the application starts, making the preference persistent across sessions.

- I changed MudSwitch in Settings.razor from @bind-Value to Value and ValueChanged.
- I implemented OnThemeSwitchChanged to call ThemeService.SetDarkModeAsync.
- I verified ThemeService already handles local storage saving and loading.
- I confirmed persistence after refresh and browser restart.