### PR TITLE
Fix: Intended IsActive display format on users table

### DIFF
--- a/Components/Pages/Admin/Users.razor
+++ b/Components/Pages/Admin/Users.razor
@@ -83,7 +83,14 @@
         <MudTd DataLabel="Email">@context.Email</MudTd>
         <MudTd DataLabel="Telefone">@context.Phone</MudTd>
         <MudTd DataLabel="Permissões">@string.Join(", ", context.RoleNames)</MudTd>
-        <MudTd DataLabel="Ativo">@context.IsActive</MudTd>
+        @if (context.IsActive)
+        {
+        <MudTd DataLabel="Ativo">Sim</MudTd>
+        }
+        else
+        {
+        <MudTd DataLabel="Ativo">Não</MudTd>
+        }
         <MudTd DataLabel="Ações"/>    
     </RowTemplate>
     <NoRecordsContent>


### PR DESCRIPTION
Simple addition to make the isactive property better understood by users

Before:
- Active user -> true
- Inactive - user -> false